### PR TITLE
Update docs for service rebrands, breaking changes, and version bumps

### DIFF
--- a/docs/beszel.md
+++ b/docs/beszel.md
@@ -1,6 +1,6 @@
 ---
 title: Deploying Beszel with Docker Compose
-description: Beszel is a self-hosted web application designed to provide a chat interface for various platforms. This guide details deploying Beszel using Docker Compose, including configuration settings for optimized performance.
+description: Beszel is a lightweight, self-hosted server monitoring hub with agent-based metrics collection. This guide details deploying Beszel using Docker Compose.
 ---
 <a href="https://my.racknerd.com/aff.php?aff=5792&ref=techdox.nz" target="_blank">
     <img src="https://racknerd.com/banners/728x90.gif" alt="RackNerd Hosting Deals">
@@ -10,7 +10,7 @@ description: Beszel is a self-hosted web application designed to provide a chat 
 
 ## Introduction to Beszel
 
-Beszel is a self-hosted web application designed to provide a chat interface for various platforms. This guide details deploying Beszel using Docker Compose, including configuration settings for optimized performance.
+[Beszel](https://github.com/henrygd/beszel) is a lightweight, self-hosted server monitoring hub that collects CPU, memory, disk, and network metrics from agents running on your servers. It provides an intuitive web dashboard to monitor all your systems in one place. This guide details deploying Beszel using Docker Compose.
 
 ## Docker Compose Configuration for Beszel
 
@@ -19,7 +19,6 @@ Here's how to set up Beszel using Docker Compose, explaining each component of t
 ### Docker Compose File (`docker-compose.yml`)
 
 ```yaml
-version: '3.8'
 services:
   beszel:
     image: 'henrygd/beszel'        # Specifies the Beszel Docker image.
@@ -63,7 +62,7 @@ After deployment, Beszel will be accessible at `http://<your-server-ip>:8090` ba
 
 ## Conclusion
 
-Deploying Beszel with Docker Compose allows for straightforward setup and management of a self-hosted chat interface. The configuration ensures optimal use of system resources while providing robust data persistence and easy accessibility.
+Deploying Beszel with Docker Compose gives you a lightweight, self-hosted monitoring hub for all your servers. Install the Beszel agent on each host you want to monitor, then add it via the web dashboard to start collecting metrics.
 
 <a href="https://www.buymeacoffee.com/techdox"><img src="https://img.buymeacoffee.com/button-api/?text=Buy me a cup of tea&emoji=🍵&slug=techdox&button_colour=FFDD00&font_colour=000000&font_family=Cookie&outline_colour=000000&coffee_colour=ffffff" /></a>
 

--- a/docs/dockge.md
+++ b/docs/dockge.md
@@ -45,7 +45,6 @@ Instead of directly using the setup from the project page, the following steps a
 Here's an example `docker-compose.yml` file for Dockge:
 
 ```yaml
-version: "3.8"
 services:
   dockge:
     image: louislam/dockge:latest
@@ -58,6 +57,8 @@ services:
       - /opt/stacks:/opt/stacks
     environment:
       - DOCKGE_STACKS_DIR=/opt/stacks
+      # Uncomment the line below to re-enable the built-in terminal (disabled by default since v1.5)
+      # - DOCKGE_ENABLE_CONSOLE=true
 ```
 
 ## Key Components of the Configuration
@@ -69,8 +70,9 @@ services:
   - `/var/run/docker.sock:/var/run/docker.sock` allows Dockge to interact with the Docker daemon.
   - `./data:/app/data` provides persistent storage for Dockge's data.
   - `/opt/stacks:/opt/stacks` maps a local directory for Docker stacks.
-- **Environment Variables**: 
+- **Environment Variables**:
   - `DOCKGE_STACKS_DIR=/opt/stacks` sets the directory path for Docker stacks within Dockge.
+  - `DOCKGE_ENABLE_CONSOLE=true` re-enables the built-in terminal, which is **disabled by default since v1.5** for security reasons.
 
 ## Deploying Dockge
 

--- a/docs/headscale.md
+++ b/docs/headscale.md
@@ -1,8 +1,11 @@
-<a href="https://my.racknerd.com/aff.php?aff=5792ref=techdox.nz" target="_blank">
+<a href="https://my.racknerd.com/aff.php?aff=5792&ref=techdox.nz" target="_blank">
     <img src="https://racknerd.com/banners/728x90.gif" alt="RackNerd Hosting Deals">
 </a>
 
 # Setting Up Headscale with Docker Compose
+
+!!! warning "Upgrade Warning"
+    Headscale has significant breaking configuration changes between minor versions. **Do not skip versions when upgrading** — you must upgrade sequentially through each minor release (e.g., 0.22 → 0.23 → 0.24 → ... → 0.28). Review the [official upgrade guide](https://headscale.net/stable/ref/upgrading/) before proceeding.
 
 ## Introduction to Headscale
 
@@ -13,11 +16,10 @@ Headscale is an open-source implementation of the Tailscale control server, prov
 ### Docker Compose File (`docker-compose.yml`)
 
 ```yaml
-version: '3.5'
 services:
   headscale:
     container_name: headscale
-    image: headscale/headscale:0.22.3
+    image: headscale/headscale:0.28.0
     volumes:
       - ./config:/etc/headscale/  # Configuration files
       - ./data:/var/lib/headscale # Data persistence
@@ -29,7 +31,7 @@ services:
 
 ### Key Components
 
-- **Image**: Uses the specific version `0.22.3` of Headscale.
+- **Image**: Uses version `0.28.0` of Headscale. Check the [releases page](https://github.com/juanfont/headscale/releases) for newer versions.
 - **Volumes**:
   - `./config`: Directory for configuration files, specifically `config.yaml`.
   - `./data`: Stores persistent data used by Headscale.
@@ -117,9 +119,9 @@ noise:
 # IPv6: https://github.com/tailscale/tailscale/blob/22ebb25e833264f58d7c3f534a8b166894a89536/net/tsaddr/tsaddr.go#LL81C52-L81C71
 # IPv4: https://github.com/tailscale/tailscale/blob/22ebb25e833264f58d7c3f534a8b166894a89536/net/tsaddr/tsaddr.go#L33
 # Any other range is NOT supported, and it will cause unexpected issues.
-ip_prefixes:
-  - 100.64.0.0/10 # you can change this value to any private ip range you want.
-  - fd7a:115c:a1e0::/48
+prefixes:
+  v4: 100.64.0.0/10
+  v6: fd7a:115c:a1e0::/48
 
 # DERP is a relay system that Tailscale uses when a direct
 # connection cannot be established.
@@ -254,58 +256,29 @@ acl_policy_path: ""
 # - https://tailscale.com/kb/1081/magicdns/
 # - https://tailscale.com/blog/2021-09-private-dns-with-magicdns/
 #
-dns_config:
+dns:
   # Whether to prefer using Headscale provided DNS or use local.
   override_local_dns: true
 
   # List of DNS servers to expose to clients.
   nameservers:
-    - 1.1.1.1
+    global:
+      - 1.1.1.1
 
-  # NextDNS (see https://tailscale.com/kb/1218/nextdns/).
-  # "abc123" is example NextDNS ID, replace with yours.
-  #
-  # With metadata sharing:
-  # nameservers:
-  #   - https://dns.nextdns.io/abc123
-  #
-  # Without metadata sharing:
-  # nameservers:
-  #   - 2a07:a8c0::ab:c123
-  #   - 2a07:a8c1::ab:c123
-
-  # Split DNS (see https://tailscale.com/kb/1054/dns/),
-  # list of search domains and the DNS to query for each one.
-  #
+  # Split DNS – list of search domains and the DNS servers to query for each.
   # restricted_nameservers:
   #   foo.bar.com:
   #     - 1.1.1.1
-  #   darp.headscale.net:
-  #     - 1.1.1.1
-  #     - 8.8.8.8
 
   # Search domains to inject.
   domains: []
 
-  # Extra DNS records
-  # so far only A-records are supported (on the tailscale side)
-  # See https://github.com/juanfont/headscale/blob/main/docs/dns-records.md#Limitations
-  # extra_records:
-  #   - name: "grafana.myvpn.example.com"
-  #     type: "A"
-  #     value: "100.64.0.3"
-  #
-  #   # you can also put it in one line
-  #   - { name: "prometheus.myvpn.example.com", type: "A", value: "100.64.0.3" }
-
-  # Whether to use [MagicDNS](https://tailscale.com/kb/1081/magicdns/).
-  # Only works if there is at least a nameserver defined.
+  # Whether to use MagicDNS (https://tailscale.com/kb/1081/magicdns/).
+  # Only works if there is at least one nameserver defined.
   magic_dns: true
 
-  # Defines the base domain to create the hostnames for MagicDNS.
-  # `base_domain` must be a FQDNs, without the trailing dot.
-  # The FQDN of the hosts will be
-  # `hostname.user.base_domain` (e.g., _myhost.myuser.example.com_).
+  # Defines the base domain for MagicDNS hostnames.
+  # Must be a FQDN without the trailing dot.
   base_domain: headscale.example.com
 
 # Unix socket used for the CLI to connect without authentication

--- a/docs/hoarder.md
+++ b/docs/hoarder.md
@@ -1,31 +1,34 @@
 ---
-title: Setting Up Hoarder with Docker Compose
-description: Hoarder is a self-hosted application for managing and organizing content efficiently. This guide explains how to deploy Hoarder using Docker Compose.
+title: Setting Up Karakeep with Docker Compose
+description: Karakeep (formerly Hoarder) is a self-hosted application for saving and organising bookmarks, links, and notes with AI-powered tagging. This guide explains how to deploy Karakeep using Docker Compose.
 ---
 <a href="https://my.racknerd.com/aff.php?aff=5792&ref=techdox.nz" target="_blank">
     <img src="https://racknerd.com/banners/728x90.gif" alt="RackNerd Hosting Deals">
 </a>
 
-# Setting Up Hoarder with Docker Compose
+# Setting Up Karakeep with Docker Compose
 
-## Introduction to Hoarder
+!!! info "Rebrand Notice"
+    Hoarder was rebranded to **Karakeep** in April 2025 due to a trademark issue. The old `ghcr.io/hoarder-app/hoarder` image is no longer updated. If you are upgrading from Hoarder, follow the [official migration guide](https://docs.karakeep.app/administration/hoarder-to-karakeep-migration/).
 
-Hoarder is a self-hosted application designed to help users manage and organize their content effortlessly. It integrates powerful tools like MeiliSearch and Alpine Chrome to enhance content indexing and browsing. This guide will walk you through the deployment of Hoarder using Docker Compose.
+## Introduction to Karakeep
+
+[Karakeep](https://karakeep.app/) is a self-hosted bookmarking and note-saving application designed to help you manage and organise content effortlessly. It integrates MeiliSearch for full-text search and a headless Chrome browser for link previews and screenshots. This guide walks you through deploying Karakeep using Docker Compose.
 
 ## Prerequisites
 
 - Docker and Docker Compose installed on your system.
 - Basic understanding of Docker Compose files.
-- A `.env` file with required environment variables.
+- A `.env` file with the required environment variables.
 
-## Docker Compose Configuration for Hoarder
+## Docker Compose Configuration for Karakeep
 
 ### Docker Compose File (`docker-compose.yml`)
 
 ```yaml
 services:
   web:
-    image: ghcr.io/hoarder-app/hoarder:${HOARDER_VERSION:-release}
+    image: ghcr.io/karakeep-app/karakeep:${KARAKEEP_VERSION:-release}
     restart: unless-stopped
     volumes:
       - data:/data
@@ -51,7 +54,7 @@ services:
       - --hide-scrollbars
 
   meilisearch:
-    image: getmeili/meilisearch:v1.11.1
+    image: getmeili/meilisearch:v1.15.0
     restart: unless-stopped
     env_file:
       - .env
@@ -68,62 +71,66 @@ volumes:
 ### Environment Variables (`.env`)
 
 ```env
-HOARDER_VERSION=release
+KARAKEEP_VERSION=release
 NEXTAUTH_SECRET=YourRandomSecureKey
 MEILI_MASTER_KEY=YourMeiliMasterKey
 NEXTAUTH_URL=http://yourdomain.com:3000
 ```
 
-- Replace `YourRandomSecureKey` with a securely generated secret (e.g., using `openssl rand -base64 32`).
+- Replace `YourRandomSecureKey` with a securely generated secret (e.g., using `openssl rand -base64 36`).
 - Replace `YourMeiliMasterKey` with a securely generated key for MeiliSearch.
 - Update `NEXTAUTH_URL` with your domain or IP address and port.
 
 ## Key Components of the Configuration
 
-### Service: `web` (Hoarder)
-- **Image**: `ghcr.io/hoarder-app/hoarder:${HOARDER_VERSION:-release}`
-- **Ports**: Maps `3000:3000` for accessing Hoarder’s web interface.
+### Service: `web` (Karakeep)
+- **Image**: `ghcr.io/karakeep-app/karakeep:${KARAKEEP_VERSION:-release}`
+- **Ports**: Maps `3000:3000` for accessing Karakeep's web interface.
 - **Environment Variables**:
   - `MEILI_ADDR`: URL of the MeiliSearch service.
   - `BROWSER_WEB_URL`: URL of the Alpine Chrome browser debugging service.
-  - `DATA_DIR`: Directory for storing Hoarder’s data.
+  - `DATA_DIR`: Directory for storing Karakeep's data.
 
 ### Service: `chrome` (Alpine Chrome)
 - **Image**: `gcr.io/zenika-hub/alpine-chrome:123`
-- **Command**: Configures Chrome for headless operation with remote debugging.
+- **Command**: Configures Chrome for headless operation with remote debugging enabled.
 
 ### Service: `meilisearch`
-- **Image**: `getmeili/meilisearch:v1.11.1`
+- **Image**: `getmeili/meilisearch:v1.15.0`
 - **Environment Variables**:
   - `MEILI_NO_ANALYTICS`: Disables analytics for privacy.
 
 ### Volumes
-- `meilisearch`: Stores MeiliSearch data persistently.
-- `data`: Stores Hoarder’s data persistently.
+- `meilisearch`: Stores MeiliSearch index data persistently.
+- `data`: Stores Karakeep's application data persistently.
 
 ## Preparing for Deployment
 
 1. **Prepare the `.env` File**: Fill out the `.env` file with secure keys and URLs as described above.
 2. **Review Configuration**: Ensure the `docker-compose.yml` and `.env` files are correctly set up for your environment.
 
-## Deploying Hoarder
+## Deploying Karakeep
 
 1. Save the configuration in a `docker-compose.yml` file and create the `.env` file in the same directory.
-2. Run the following command to start Hoarder and its dependencies:
+2. Run the following command to start Karakeep and its dependencies:
    ```bash
    docker compose up -d
    ```
-3. Access Hoarder at `http://yourdomain.com:3000` (replace with your actual domain or IP and port).
+3. Access Karakeep at `http://yourdomain.com:3000` (replace with your actual domain or IP and port).
 
 ## Post-Deployment Tips
 
-- **Reverse Proxy**: For improved security and accessibility, consider using a reverse proxy (e.g., Nginx or Traefik) to serve Hoarder over HTTPS.
-- **OpenAI API Key**: If you plan to integrate OpenAI features, set the `OPENAI_API_KEY` in the `.env` file.
-- **Secure Your Setup**: Use strong passwords and secrets for all environment variables.
+- **Reverse Proxy**: For improved security and accessibility, consider using a reverse proxy (e.g., Nginx Proxy Manager or Traefik) to serve Karakeep over HTTPS.
+- **OpenAI API Key**: If you plan to use AI-powered tagging, set the `OPENAI_API_KEY` in the `.env` file.
+- **Secure Your Setup**: Use strong, randomly generated secrets for all environment variables.
 
 ## Troubleshooting
 
 - **Service Not Starting**: Check for missing or incorrect values in the `.env` file.
-- **Connection Issues**: Verify that the `MEILI_ADDR` and `BROWSER_WEB_URL` are correctly configured and accessible.
+- **Connection Issues**: Verify that `MEILI_ADDR` and `BROWSER_WEB_URL` are correctly configured and that those services are running.
 
 <a href="https://www.buymeacoffee.com/techdox"><img src="https://img.buymeacoffee.com/button-api/?text=Buy me a cup of tea&emoji=🍵&slug=techdox&button_colour=FFDD00&font_colour=000000&font_family=Cookie&outline_colour=000000&coffee_colour=ffffff" /></a>
+
+---
+
+If there is an issue with this guide or you wish to suggest changes, please raise an issue on [GitHub](https://github.com/Techdox/techdox-docs).

--- a/docs/nexterm.md
+++ b/docs/nexterm.md
@@ -21,7 +21,7 @@ Below is the Docker Compose file used to deploy Nexterm, with an explanation of 
 ```yaml
 services:
   nexterm:
-    image: germannewsmaker/nexterm:1.0.1-OPEN-PREVIEW # Specifies the Docker image for Nexterm.
+    image: germannewsmaker/nexterm:1.0.9-OPEN-PREVIEW # Specifies the Docker image for Nexterm.
     ports:
       - "6989:6989"                                   # Exposes port 6989 for accessing Nexterm's interface.
     restart: always                                   # Ensures the container restarts automatically if stopped.
@@ -34,7 +34,7 @@ volumes:
 
 ### Explanation of Key Components
 
-- **Image**: Specifies the Docker image `germannewsmaker/nexterm:1.0.1-OPEN-PREVIEW`, which is the preview version of Nexterm.
+- **Image**: Specifies the Docker image `germannewsmaker/nexterm:1.0.9-OPEN-PREVIEW`. Nexterm is currently in open preview; check [releases](https://github.com/gnmyt/Nexterm/releases) for the latest tag.
 - **Ports**: Maps port `6989` on the host to port `6989` inside the container, allowing access to Nexterm via `http://<your-server-ip>:6989`.
 - **Volumes**: A named volume `nexterm:/app/data` is used to persist data. This volume ensures that configuration and data are retained across container restarts.
 - **Restart**: Configured to `always` so the container will automatically restart in case of failures.

--- a/docs/pangolin.md
+++ b/docs/pangolin.md
@@ -27,11 +27,16 @@ If you're looking for an affordable VPS, consider [RackNerd](https://my.racknerd
 
 ### 1. Download and Run the Installer
 
-Download the installer for your system:
+Download the latest installer for your system:
 
 ```bash
-wget -O installer "https://github.com/fosrl/pangolin/releases/download/1.2.0/installer_linux_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')" && chmod +x ./installer
+PANGOLIN_VERSION=$(curl -s https://api.github.com/repos/fosrl/pangolin/releases/latest | grep '"tag_name"' | cut -d'"' -f4) && \
+wget -O installer "https://github.com/fosrl/pangolin/releases/download/${PANGOLIN_VERSION}/installer_linux_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')" && \
+chmod +x ./installer
 ```
+
+!!! tip
+    The command above automatically fetches the latest release. You can check available releases at the [Pangolin releases page](https://github.com/fosrl/pangolin/releases).
 
 Run the installer with root privileges:
 

--- a/docs/pocketid.md
+++ b/docs/pocketid.md
@@ -43,7 +43,7 @@ services:
 
 - **pocket-id**: Runs the Pocket ID application.
 - **Image**: Pulls the latest image from the Pocket ID GitHub Container Registry.
-- **Ports**: Maps port 3055 on the host to port 80 in the container, making Pocket ID accessible via `http://<your-server-ip>:3055`.
+- **Ports**: Maps port 3055 on the host to port 1411 in the container, making Pocket ID accessible via `http://<your-server-ip>:3055`.
 - **Volumes**:
   - `./data:/app/backend/data`: Mounts the local data directory for persistent storage.
 - **Healthcheck**: Ensures the container is running properly and provides automated health monitoring.
@@ -57,13 +57,13 @@ Pocket ID requires environment variables for proper configuration. These setting
 ```env
 # Documentation: https://pocket-id.org/docs/configuration/environment-variables
 APP_URL=https://pocket.techdox.nz         # Public URL for your Pocket ID instance
+ENCRYPTION_KEY=your_32_byte_base64_key    # REQUIRED – generate with: openssl rand -base64 32
 TRUST_PROXY=true                          # Enables reverse proxy support
 MAXMIND_LICENSE_KEY=                      # (Optional) License key for GeoIP features
-PUID=1000                                 # User ID for file permission management
-PGID=1000                                 # Group ID for file permission management
 ```
 
 **Note**:
+- `ENCRYPTION_KEY` is **mandatory** since Pocket ID v2.0. The container will not start without it. Generate a key with `openssl rand -base64 32`.
 - Replace the placeholder values with your specific configuration.
 - For detailed explanations, visit the [Pocket ID environment variables documentation](https://pocket-id.org/docs/configuration/environment-variables).
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -28,7 +28,7 @@ nav:
           - Excalidraw: excalidraw.md
           - Firefly III: firefly.md
           - Focalboard: focalboard.md
-          - Hoarder: hoarder.md
+          - Karakeep: hoarder.md
           - Joplin: joplin.md
           - Mealie: mealie.md
           - Memos: memos.md


### PR DESCRIPTION
- Karakeep: full rebrand from Hoarder (new image, env vars, Meilisearch v1.15.0)
- Pocket ID: add mandatory ENCRYPTION_KEY (v2.0+), fix port description, remove removed PUID/PGID vars
- Pangolin: replace hardcoded v1.2.0 installer with dynamic latest-release command
- Headscale: bump image 0.22.3→0.28.0, fix broken URL, update config for v0.28 syntax, add upgrade warning
- Dockge: remove deprecated version key, document Console disabled by default since v1.5
- Beszel: fix completely wrong description (was "chat interface"), remove deprecated version key
- Nexterm: bump image tag 1.0.1→1.0.9-OPEN-PREVIEW
- mkdocs.yml: rename nav entry Hoarder→Karakeep