### PR TITLE
Add Homelab Rebuild 2026 documentation section (10 pages)

### DIFF
--- a/docs/homelab-rebuild/architecture.md
+++ b/docs/homelab-rebuild/architecture.md
@@ -1,0 +1,124 @@
+---
+title: Full Stack Architecture Diagram
+description: Complete architecture diagram of the homelab rebuild stack, showing all layers from network to identity.
+---
+<a href="https://my.racknerd.com/aff.php?aff=5792&ref=techdox.nz" target="_blank">
+    <img src="https://racknerd.com/banners/728x90.gif" alt="RackNerd Hosting Deals">
+</a>
+
+# Full Stack Architecture
+
+This page shows the complete picture of how all the layers in the [Homelab Rebuild](index.md) connect to each other.
+
+---
+
+## Network & DNS Layer
+
+```mermaid
+flowchart TD
+    Internet([Internet]) --> ISP[ISP Modem / ONT]
+    ISP -->|WAN / DHCP| OPN["OPNsense\n(Zimaboard 2)\nFirewall · DHCP · NAT"]
+
+    OPN -->|LAN 192.168.1.0/24| SW[Switch / AP]
+    SW --> Devices([LAN devices\nDesktops · Phones · IoT])
+
+    OPN -->|Inline traffic inspection| IDS[Suricata IDS]
+
+    OPN -->|DHCP Option 6 → Pi-hole IP| PIHOLE["Pi-hole\nAd blocking · Local DNS"]
+    PIHOLE -->|Upstream: router LAN IP:53| UNB["Unbound\n(on OPNsense)\nRecursive + DNSSEC"]
+    UNB -->|Iterative queries| ROOT([Root · TLD · Auth DNS])
+```
+
+---
+
+## Remote Access Layer
+
+```mermaid
+flowchart LR
+    Phone([iPhone\nFull tunnel]) -->|WireGuard UDP 51820| WG
+    Laptop([MacBook\nSplit tunnel]) -->|WireGuard UDP 51820| WG
+
+    WG["WireGuard\n(on OPNsense)\n10.10.10.0/24"] -->|Tunnel traffic| OPN[OPNsense]
+    OPN --> LAN([LAN services])
+
+    subgraph NAT Rules
+        NAT1[WireGuard → WAN\nInternet access]
+        NAT2[WireGuard → LAN\nPi-hole DNS replies]
+    end
+```
+
+---
+
+## Public Services Layer
+
+```mermaid
+flowchart LR
+    User([External user]) -->|HTTPS| CF[Cloudflare Edge\nDDoS protection · TLS]
+    CF -->|Tunnel QUIC/HTTP2| CFD[cloudflared daemon\non service host]
+    CFD --> SVC([Self-hosted service\nport on localhost])
+
+    subgraph Internal path
+        LAN([LAN client]) -->|DNS: Pi-hole local record| NPM[Nginx Proxy Manager\nInternal TLS · Let's Encrypt]
+        NPM --> SVC2([Same service\ndifferent path])
+    end
+```
+
+---
+
+## Identity & Authentication Layer
+
+```mermaid
+flowchart TD
+    subgraph Identity Stack
+        PM["Proton Mail\nCustom domain email"]
+        PW["Proton Pass\nPassword manager"]
+        PA["Proton Authenticator\nTOTP 2FA"]
+    end
+
+    subgraph Hardware Auth
+        YK1["YubiKey (primary)\nFIDO2 SSH · Account 2FA"]
+        YK2["YubiKey (backup)\nIdentical setup\nStored separately"]
+    end
+
+    SSH[SSH to servers] -->|ed25519-sk key| YK1
+    Accounts[Online accounts] -->|FIDO2 hardware key| YK1
+```
+
+---
+
+## Device Security Layer
+
+```mermaid
+flowchart TD
+    subgraph macOS Hardening
+        FV[FileVault\nFull disk encryption]
+        FW[Application Firewall\nInbound blocking]
+        LULU[LuLu\nOutbound app firewall]
+        BB[BlockBlock\nPersistence monitor]
+        OS[OverSight\nMic · Camera alerts]
+        ADP[iCloud ADP\nEnd-to-end encrypted backups]
+    end
+```
+
+---
+
+## Full Stack Summary
+
+| Layer | Components | Guides |
+|-------|-----------|--------|
+| Network | OPNsense, Zimaboard 2, TP-Link Deco (AP mode) | [OPNsense](opnsense-zimaboard.md) |
+| Intrusion Detection | Suricata IDS | [OPNsense](opnsense-zimaboard.md) |
+| DNS | Pi-hole + Unbound + DNSSEC | [DNS Stack](dns-stack.md) |
+| DHCP + Local DNS | Dnsmasq (on OPNsense) | [OPNsense](opnsense-zimaboard.md) |
+| Remote Access | WireGuard on OPNsense | [WireGuard VPN](wireguard-vpn.md) |
+| Public Services | Cloudflare Tunnels | [Cloudflare Tunnels](cloudflare-tunnels.md) |
+| Internal TLS | Nginx Proxy Manager + Pi-hole local DNS | [Internal Hostnames](internal-hostnames.md) |
+| Email | Proton Mail with custom domain | [Proton Mail](proton-mail-custom-domain.md) |
+| Authentication | YubiKey FIDO2 SSH | [YubiKey SSH](yubikey-ssh.md) |
+| Device | macOS + Objective-See tools | [macOS Hardening](macos-hardening.md) |
+
+<a href="https://www.buymeacoffee.com/techdox"><img src="https://img.buymeacoffee.com/button-api/?text=Buy me a cup of tea&emoji=🍵&slug=techdox&button_colour=FFDD00&font_colour=000000&font_family=Cookie&outline_colour=000000&coffee_colour=ffffff" /></a>
+
+---
+
+If there is an issue with this guide or you wish to suggest changes, please raise an issue on [GitHub](https://github.com/Techdox/techdox-docs).

--- a/docs/homelab-rebuild/cloudflare-tunnels.md
+++ b/docs/homelab-rebuild/cloudflare-tunnels.md
@@ -1,0 +1,172 @@
+---
+title: Cloudflare Tunnels for Public Services
+description: Expose self-hosted services to the internet without opening a single port. Cloudflare Tunnels create an outbound-only connection from cloudflared to Cloudflare's edge.
+---
+<a href="https://my.racknerd.com/aff.php?aff=5792&ref=techdox.nz" target="_blank">
+    <img src="https://racknerd.com/banners/728x90.gif" alt="RackNerd Hosting Deals">
+</a>
+
+# Cloudflare Tunnels for Public Services
+
+Port forwarding is the traditional way to expose a home service publicly. It works, but it exposes your real IP, requires managing firewall rules, and puts you one misconfiguration away from an exposed service. Cloudflare Tunnels take the opposite approach: your server makes an outbound connection to Cloudflare's edge, and all inbound traffic comes through that tunnel. No open ports, no exposed IP.
+
+## Prerequisites
+
+- A domain registered and managed with Cloudflare DNS
+- A free Cloudflare account (tunnels are included at no cost)
+- A host running your service (VM, container, bare metal)
+- Docker or the ability to install `cloudflared` as a binary or systemd service
+
+---
+
+## Why Cloudflare Tunnels Over Port Forwarding
+
+| Feature | Port Forwarding | Cloudflare Tunnels |
+|---------|----------------|-------------------|
+| Open ports on router | ✅ Required | ❌ None |
+| Real IP exposed | ✅ Yes | ❌ Hidden |
+| DDoS protection | ❌ None | ✅ Cloudflare edge |
+| Free SSL | ❌ Manual setup | ✅ Automatic |
+| Access control layer | ❌ Manual | ✅ Cloudflare Access (optional) |
+| Works behind CGNAT | ❌ No | ✅ Yes |
+
+The last point is important for mobile broadband or ISPs using Carrier-Grade NAT (CGNAT) — you literally can't port forward in those situations. Tunnels work regardless.
+
+---
+
+## How It Works
+
+```
+Your service (e.g., port 8080 on your server)
+    ↑
+cloudflared daemon (running on your server or network)
+    ↓ (outbound QUIC/HTTP2 connection to Cloudflare)
+Cloudflare edge
+    ↑
+Public user requests service.yourdomain.com
+```
+
+The `cloudflared` process maintains a persistent outbound connection to Cloudflare. When a user visits your domain, traffic flows in through Cloudflare and back through the tunnel to your service. Your server never needs an inbound firewall rule.
+
+---
+
+## Setup Overview
+
+For detailed first-time setup, follow [Cloudflare's official tunnel documentation](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/). The steps below assume you're familiar with the basics.
+
+### 1. Install cloudflared
+
+**Docker Compose (recommended for homelab)**:
+
+```yaml
+services:
+  cloudflared:
+    image: cloudflare/cloudflared:latest
+    restart: unless-stopped
+    command: tunnel --no-autoupdate run
+    environment:
+      - TUNNEL_TOKEN=your_tunnel_token_here
+```
+
+**Or as a binary on the host**:
+
+```bash
+# Debian/Ubuntu
+curl -L https://pkg.cloudflare.com/cloudflare-main.gpg | sudo tee /usr/share/keyrings/cloudflare-main.gpg > /dev/null
+echo 'deb [signed-by=/usr/share/keyrings/cloudflare-main.gpg] https://pkg.cloudflare.com/cloudflared any main' | sudo tee /etc/apt/sources.list.d/cloudflared.list
+sudo apt update && sudo apt install cloudflared
+```
+
+### 2. Authenticate and Create a Tunnel
+
+```bash
+cloudflared tunnel login
+cloudflared tunnel create my-homelab
+```
+
+### 3. Configure Ingress Rules
+
+Create `~/.cloudflared/config.yml`:
+
+```yaml
+tunnel: <your-tunnel-id>
+credentials-file: /root/.cloudflared/<tunnel-id>.json
+
+ingress:
+  - hostname: service1.yourdomain.com
+    service: http://localhost:8080
+  - hostname: service2.yourdomain.com
+    service: http://192.168.1.x:3000
+  - service: http_status:404
+```
+
+Each `hostname` entry maps a public domain to a local service by IP/port.
+
+### 4. Add DNS Routes
+
+```bash
+cloudflared tunnel route dns my-homelab service1.yourdomain.com
+cloudflared tunnel route dns my-homelab service2.yourdomain.com
+```
+
+This creates `CNAME` records in Cloudflare DNS pointing each subdomain at the tunnel.
+
+### 5. Run the Tunnel
+
+```bash
+cloudflared tunnel run my-homelab
+# Or as a systemd service:
+sudo cloudflared service install
+sudo systemctl start cloudflared
+```
+
+---
+
+## Integrating with Internal Services
+
+For a homelab running both public and internal services on the same domain:
+
+| Access path | How it works |
+|-------------|--------------|
+| Public (`service.yourdomain.com` from internet) | Cloudflare Tunnel → service |
+| Internal (`service.yourdomain.com` from LAN) | Pi-hole local DNS record → Nginx Proxy Manager → service |
+
+The same domain resolves differently depending on where the client is. Internal clients get the NPM IP from Pi-hole's local DNS; external clients go through Cloudflare. See [Internal Hostnames](internal-hostnames.md) for the internal side of this setup.
+
+---
+
+## Optional: Cloudflare Access (Zero-Trust Auth Layer)
+
+Cloudflare Access adds an authentication layer in front of any tunnelled service. Users must authenticate (via email OTP, Google, GitHub, etc.) before they can even reach your service.
+
+Useful for:
+- Admin panels you don't want publicly accessible
+- Services without their own authentication
+- Adding MFA without modifying the service
+
+Configure in **Cloudflare Zero Trust → Access → Applications**.
+
+---
+
+## Common Gotchas
+
+| Problem | Cause | Fix |
+|---------|-------|-----|
+| Tunnel connects but service unreachable | Ingress rule IP/port wrong | Check service is listening on the specified address |
+| `502 Bad Gateway` | Service not running or wrong port | Verify with `curl http://localhost:<port>` on the host |
+| DNS not resolving | CNAME not created | Run `cloudflared tunnel route dns` for the hostname |
+| Tunnel drops frequently | Old cloudflared version | Update to latest: `apt upgrade cloudflared` |
+| Large file uploads failing | Cloudflare's 100MB upload limit on free plan | Use a paid plan or serve large uploads internally only |
+
+---
+
+## Related Pages
+
+- [Internal Hostnames](internal-hostnames.md) — the internal counterpart to this guide
+- [OPNsense on Zimaboard 2](opnsense-zimaboard.md) — no firewall rules needed for tunnels, but useful context
+
+<a href="https://www.buymeacoffee.com/techdox"><img src="https://img.buymeacoffee.com/button-api/?text=Buy me a cup of tea&emoji=🍵&slug=techdox&button_colour=FFDD00&font_colour=000000&font_family=Cookie&outline_colour=000000&coffee_colour=ffffff" /></a>
+
+---
+
+If there is an issue with this guide or you wish to suggest changes, please raise an issue on [GitHub](https://github.com/Techdox/techdox-docs).

--- a/docs/homelab-rebuild/dns-stack.md
+++ b/docs/homelab-rebuild/dns-stack.md
@@ -1,0 +1,155 @@
+---
+title: Pi-hole + Unbound DNS Stack
+description: Build a fully self-contained DNS stack with Pi-hole for ad blocking and Unbound for recursive resolution. No queries leave to Cloudflare, Google, or your ISP.
+---
+<a href="https://my.racknerd.com/aff.php?aff=5792&ref=techdox.nz" target="_blank">
+    <img src="https://racknerd.com/banners/728x90.gif" alt="RackNerd Hosting Deals">
+</a>
+
+# Pi-hole + Unbound DNS Stack
+
+Most home networks send DNS queries to Cloudflare (1.1.1.1) or Google (8.8.8.8). Those companies log your queries, build profiles, and in Google's case, tie the data to your account. This guide builds a stack where your DNS queries never leave your network — Pi-hole blocks ads and trackers, Unbound resolves everything directly from root servers, and DNSSEC validates responses end-to-end.
+
+## Prerequisites
+
+- Pi-hole running on a dedicated host (Raspberry Pi, VM, or container) with a static IP
+- OPNsense router (see [OPNsense on Zimaboard 2](opnsense-zimaboard.md)) — or any router that lets you configure DHCP option 6 and run Unbound
+- Basic familiarity with Pi-hole's admin interface
+
+---
+
+## Architecture
+
+```
+Client device
+    ↓ (DNS via DHCP option 6)
+Pi-hole (192.168.1.x)
+    ↓ (upstream: Unbound on OPNsense)
+Unbound (192.168.1.1 port 53)
+    ↓ (iterative query)
+Root DNS servers → TLD servers → Authoritative servers
+```
+
+- Client devices receive Pi-hole's IP as their DNS server via DHCP
+- Pi-hole performs ad/tracker blocking via its gravity lists
+- Blocked domains return `0.0.0.0` — the client gets nothing, the ad never loads
+- Unblocked queries are forwarded to Unbound on OPNsense
+- Unbound resolves the query iteratively — no third-party DNS involved
+- DNSSEC validation happens at the Unbound level
+
+---
+
+## Configuring Unbound on OPNsense
+
+Navigate to **Services → Unbound DNS → General**:
+
+| Setting | Value |
+|---------|-------|
+| Enable Unbound | ✅ |
+| Listen Port | `53` |
+| Network Interfaces | `LAN` only — **never** WAN |
+| Enable DNSSEC Support | ✅ |
+| Local Zone Type | `transparent` |
+
+!!! warning "Never enable Unbound on the WAN interface"
+    Binding Unbound to WAN makes your resolver publicly accessible, turning it into an open resolver that anyone on the internet can abuse for DNS amplification attacks. LAN only.
+
+Save and apply. Unbound is now listening on your router's LAN IP on port 53.
+
+---
+
+## Configuring Pi-hole
+
+### Point Pi-hole at Unbound
+
+In Pi-hole's admin interface: **Settings → DNS → Upstream DNS Servers**
+
+- Uncheck all public resolvers (Cloudflare, Google, Quad9, OpenDNS)
+- Under **Custom**, enter your OPNsense LAN IP with port 53:
+
+```
+192.168.1.1#53
+```
+
+(Replace `192.168.1.1` with your OPNsense LAN IP if different.)
+
+Save and apply. Pi-hole now sends all non-blocked queries to Unbound rather than a public resolver.
+
+### (Optional) Enable DNSSEC in Pi-hole
+
+Pi-hole can also display DNSSEC status in its query log. Under **Settings → DNS**:
+
+- Enable **Use DNSSEC**
+
+This is display-only when using Unbound as upstream — Unbound handles the actual validation — but it confirms validation status in Pi-hole's logs.
+
+---
+
+## Verifying the Chain
+
+Run these checks from a device on your network:
+
+```bash
+# 1. Check Pi-hole is responding
+dig @192.168.1.x google.com
+# Should return A records with status: NOERROR
+
+# 2. Check ad blocking works
+dig @192.168.1.x doubleclick.net
+# Should return 0.0.0.0 (blocked by Pi-hole gravity)
+
+# 3. Check DNSSEC validation
+dig @192.168.1.x dnssec-failed.org
+# Should return SERVFAIL — this domain intentionally fails DNSSEC
+# If you get an A record back, DNSSEC is NOT working
+
+# 4. Trace the recursive resolution path
+dig +trace google.com
+# Shows the full chain: root → .com TLD → google.com authoritative
+```
+
+!!! tip
+    The `dnssec-failed.org` test is the most important one. If DNSSEC is working correctly, this domain returns `SERVFAIL`. If it returns an IP address, something in your chain isn't validating signatures.
+
+---
+
+## Why This is Better Than Common Alternatives
+
+| Approach | DNS data goes to | Ad blocking | DNSSEC |
+|----------|-----------------|-------------|--------|
+| ISP default | Your ISP | ❌ | ❌ |
+| Cloudflare 1.1.1.1 | Cloudflare | ❌ | ✅ |
+| Pi-hole → Cloudflare | Cloudflare | ✅ | ✅ |
+| Pi-hole → Unbound (this guide) | Nobody | ✅ | ✅ |
+
+With Pi-hole + Unbound:
+
+- **No DNS data leaves your network** to any third party
+- **Network-wide ad blocking** for all devices including phones, TVs, and IoT
+- **DNSSEC validation** prevents DNS spoofing and cache poisoning
+- **Local hostname resolution** via Dnsmasq host overrides on OPNsense (see [OPNsense setup](opnsense-zimaboard.md#host-overrides))
+
+---
+
+## Common Gotchas
+
+| Problem | Cause | Fix |
+|---------|-------|-----|
+| Pi-hole showing no queries | Devices using a different DNS | Check DHCP option 6 is set to Pi-hole IP |
+| `SERVFAIL` on all domains | Unbound not running, or wrong IP in Pi-hole | Verify Unbound is enabled; check the upstream IP |
+| Ads still showing on some apps | App using DNS-over-HTTPS (DoH) bypassing Pi-hole | Block known DoH providers in Pi-hole, or block port 853 at the firewall |
+| Local hostnames not resolving | Dnsmasq host overrides not configured | See [OPNsense host overrides](opnsense-zimaboard.md#host-overrides) |
+
+---
+
+## Related Pages
+
+- [OPNsense on Zimaboard 2](opnsense-zimaboard.md) — set up DHCP option 6 and Dnsmasq host overrides
+- [Internal Hostnames](internal-hostnames.md) — serve internal services with proper domain names
+- [WireGuard VPN](wireguard-vpn.md) — Pi-hole filtering works through the VPN too with the right NAT rules
+
+<a href="https://www.buymeacoffee.com/techdox"><img src="https://img.buymeacoffee.com/button-api/?text=Buy me a cup of tea&emoji=🍵&slug=techdox&button_colour=FFDD00&font_colour=000000&font_family=Cookie&outline_colour=000000&coffee_colour=ffffff" /></a>
+
+---
+
+If there is an issue with this guide or you wish to suggest changes, please raise an issue on [GitHub](https://github.com/Techdox/techdox-docs).

--- a/docs/homelab-rebuild/index.md
+++ b/docs/homelab-rebuild/index.md
@@ -1,0 +1,125 @@
+---
+title: Homelab Rebuild 2026 — Overview & Architecture
+description: A complete rebuild of a personal homelab and identity stack, covering open-source routing, full DNS sovereignty, encrypted remote access, zero exposed ports, and identity privacy.
+---
+<a href="https://my.racknerd.com/aff.php?aff=5792&ref=techdox.nz" target="_blank">
+    <img src="https://racknerd.com/banners/728x90.gif" alt="RackNerd Hosting Deals">
+</a>
+
+# Homelab Rebuild 2026 — Overview
+
+This section documents a complete rebuild of a personal homelab and privacy stack from the ground up. Rather than just adding services on top of a consumer router, this rebuild takes a different approach: every layer — network, DNS, remote access, authentication, and identity — is purpose-built, open-source where possible, and designed with privacy and security as first-class requirements.
+
+If you're running a similar setup or planning to level up from a consumer router, these guides are written from real experience, including the gotchas that most docs skip over.
+
+## Goals
+
+- **Open-source routing** — replace a consumer mesh router with OPNsense running on x86 hardware
+- **Full DNS sovereignty** — no DNS queries leaving to Cloudflare, Google, or the ISP
+- **Encrypted remote access** — WireGuard VPN built into the router, zero exposed ports
+- **Public services without port forwarding** — Cloudflare Tunnels as the only inbound path
+- **Hardware-bound authentication** — YubiKey FIDO2 for SSH and account security
+- **Identity privacy** — Proton Mail with custom domain, no dependency on Big Tech for email
+
+---
+
+## Architecture Overview
+
+```mermaid
+flowchart TD
+    Internet([Internet]) --> ISP[ISP Modem/ONT]
+    ISP --> OPN[OPNsense Firewall\nZimaboard 2]
+
+    OPN --> IDS[Suricata IDS\nInline detection]
+    OPN --> DNS[Pi-hole\nNetwork DNS]
+    DNS --> UNB[Unbound\nRecursive resolver]
+    UNB --> Root([Root DNS servers])
+
+    OPN --> WG[WireGuard VPN\nKernel-level]
+    WG --> Clients([Remote devices\niPhone / MacBook])
+
+    OPN --> Mesh[TP-Link Deco\nAccess Point mode]
+    Mesh --> Devices([LAN devices])
+
+    OPN --> NPM[Nginx Proxy Manager\nInternal TLS]
+    NPM --> Services([Self-hosted services])
+
+    CF[Cloudflare Tunnels\nZero exposed ports] --> Services
+    Internet --> CF
+
+    subgraph Identity
+        PM[Proton Mail]
+        PW[Proton Pass]
+        YK[YubiKey FIDO2]
+        PA[Proton Authenticator]
+    end
+```
+
+---
+
+## Component List
+
+### Network Layer
+
+| Component | Role |
+|-----------|------|
+| OPNsense on Zimaboard 2 | Router, firewall, DHCP, DNS forwarder |
+| TP-Link Deco (AP mode) | Wi-Fi access points only, routing disabled |
+| Suricata IDS | Inline intrusion detection |
+
+### DNS Layer
+
+| Component | Role |
+|-----------|------|
+| Pi-hole | Network-wide ad/tracker blocking, LAN DNS |
+| Unbound (on OPNsense) | Recursive resolver, DNSSEC validation |
+| Dnsmasq (on OPNsense) | DHCP + local hostname resolution |
+
+### Remote Access
+
+| Component | Role |
+|-----------|------|
+| WireGuard (OPNsense) | Kernel-level VPN, split or full tunnel |
+| Cloudflare Tunnels | Outbound-only path for public services |
+
+### Identity & Authentication
+
+| Component | Role |
+|-----------|------|
+| Proton Mail | Privacy-first email on custom domain |
+| Proton Pass | Password manager |
+| Proton Authenticator | TOTP 2FA |
+| YubiKey (×2) | FIDO2 SSH, account hardware keys |
+
+### Device Security (macOS)
+
+| Component | Role |
+|-----------|------|
+| FileVault | Full disk encryption |
+| LuLu | Outbound application firewall |
+| BlockBlock | Persistence monitor |
+| OverSight | Mic/camera access alerts |
+
+---
+
+## Section Guide
+
+| Page | What it covers |
+|------|----------------|
+| [OPNsense on Zimaboard 2](opnsense-zimaboard.md) | Hardware setup, install, initial config, DHCP, cutover |
+| [Pi-hole + Unbound DNS](dns-stack.md) | Full DNS sovereignty stack, DNSSEC, ad blocking |
+| [WireGuard VPN](wireguard-vpn.md) | Router-level WireGuard, split/full tunnel, firewall + NAT rules |
+| [YubiKey SSH](yubikey-ssh.md) | FIDO2 SSH with ed25519-sk keys, macOS setup |
+| [Cloudflare Tunnels](cloudflare-tunnels.md) | Public services with zero port exposure |
+| [Internal Hostnames](internal-hostnames.md) | NPM + Pi-hole local DNS, internal TLS |
+| [Proton Mail Migration](proton-mail-custom-domain.md) | Custom domain email migration, MX/SPF/DKIM/DMARC |
+| [macOS Hardening](macos-hardening.md) | Native protections + Objective-See toolkit |
+| [Architecture Diagram](architecture.md) | Full stack diagram with all layers |
+
+---
+
+<a href="https://www.buymeacoffee.com/techdox"><img src="https://img.buymeacoffee.com/button-api/?text=Buy me a cup of tea&emoji=🍵&slug=techdox&button_colour=FFDD00&font_colour=000000&font_family=Cookie&outline_colour=000000&coffee_colour=ffffff" /></a>
+
+---
+
+If there is an issue with this guide or you wish to suggest changes, please raise an issue on [GitHub](https://github.com/Techdox/techdox-docs).

--- a/docs/homelab-rebuild/internal-hostnames.md
+++ b/docs/homelab-rebuild/internal-hostnames.md
@@ -1,0 +1,158 @@
+---
+title: Internal Hostnames with NPM and Pi-hole
+description: Serve internal self-hosted services at real domain names with HTTPS using Nginx Proxy Manager and Pi-hole local DNS records. No public exposure required.
+---
+<a href="https://my.racknerd.com/aff.php?aff=5792&ref=techdox.nz" target="_blank">
+    <img src="https://racknerd.com/banners/728x90.gif" alt="RackNerd Hosting Deals">
+</a>
+
+# Internal Hostnames with NPM and Pi-hole
+
+Running self-hosted services at bare IPs and ports (`http://192.168.1.x:8080`) is functional but messy. This guide sets up proper domain names for internal services with HTTPS — so you can access them as `https://service.yourdomain.com` from inside your network, with a valid certificate, without exposing anything publicly.
+
+## Prerequisites
+
+- [Nginx Proxy Manager](../npm.md) running on your network with a static IP
+- Pi-hole running with local DNS access
+- A domain with Cloudflare DNS (required for DNS-01 certificate challenges on internal-only domains)
+- OPNsense or any router with Dnsmasq host overrides (see [OPNsense setup](opnsense-zimaboard.md))
+
+---
+
+## Architecture
+
+```
+Internal client
+    ↓ (DNS query: service.yourdomain.com)
+Pi-hole
+    ↓ (local DNS record: service.yourdomain.com → NPM IP)
+Nginx Proxy Manager (192.168.1.x)
+    ↓ (proxy pass to service backend)
+Service (192.168.1.y:port)
+```
+
+Pi-hole intercepts the DNS query and returns NPM's internal IP. The client connects to NPM, which terminates TLS and proxies to the backend. The certificate is valid because it was issued via DNS-01 challenge — no HTTP challenge needed, so no public exposure required.
+
+---
+
+## Step 1: Add a Local DNS Record in Pi-hole
+
+For each service you want to serve internally:
+
+1. Open Pi-hole admin → **Local DNS → DNS Records**
+2. Click **Add**
+3. Set **Domain** to your service hostname (e.g., `service.yourdomain.com`)
+4. Set **IP Address** to your NPM host IP (e.g., `192.168.1.x`)
+5. Save
+
+!!! tip
+    You can use any subdomain you own. Using your real domain (not `.local`) means you can get a valid publicly-trusted certificate via DNS-01 challenge, which `.local` domains cannot get.
+
+---
+
+## Step 2: Create a Proxy Host in NPM
+
+1. Open NPM → **Proxy Hosts → Add Proxy Host**
+2. Set **Domain Names** to the same hostname (e.g., `service.yourdomain.com`)
+3. Set **Scheme** to `http` (or `https` if the backend uses it)
+4. Set **Forward Hostname / IP** to the service's internal IP
+5. Set **Forward Port** to the service's port
+6. Enable **Websockets Support** if the service needs it
+
+---
+
+## Step 3: Request a Certificate (DNS-01)
+
+In the **SSL** tab of the proxy host:
+
+1. Select **Request a new SSL Certificate**
+2. Enable **Force SSL**
+3. Select **DNS Challenge**
+4. Choose **Cloudflare** as the DNS provider
+5. Enter your Cloudflare API token (needs `Zone → DNS → Edit` permissions)
+6. Request the certificate
+
+DNS-01 challenges prove domain ownership by creating a TXT record in DNS, which Cloudflare handles automatically. Your service never needs to be publicly reachable for the certificate to issue.
+
+!!! note "Wildcard certificate option"
+    If you have many internal services on the same domain, request a wildcard certificate for `*.yourdomain.com` once and reuse it across all proxy hosts. This avoids rate limits and simplifies renewal.
+
+---
+
+## Step 4: Advanced — Proxying Self-Signed Backends
+
+If the service you're proxying uses HTTPS with a self-signed certificate (some services default to this):
+
+In NPM's **Advanced** tab for the proxy host, add:
+
+```nginx
+proxy_ssl_verify off;
+```
+
+This tells NPM not to validate the backend's certificate (since it's self-signed). The connection from client to NPM is still fully valid TLS.
+
+---
+
+## OPNsense Web UI Gotcha
+
+If you're proxying OPNsense's web interface through NPM, you'll get HTTP_REFERER errors unless you tell OPNsense about the alternate hostname.
+
+Navigate to **System → Settings → Administration → Alternate Hostnames** and add:
+
+- Your NPM proxy hostname (e.g., `opnsense.yourdomain.com`)
+- NPM's own hostname if you're also proxying NPM itself
+
+---
+
+## Combining Internal and Public Services
+
+This setup pairs naturally with [Cloudflare Tunnels](cloudflare-tunnels.md). The same domain resolves differently depending on where the client is:
+
+| Client location | DNS resolution | Path |
+|----------------|----------------|------|
+| Inside LAN | Pi-hole local DNS → NPM IP | NPM → service (internal TLS) |
+| Outside LAN | Cloudflare public DNS → Tunnel CNAME | Cloudflare Tunnel → service |
+
+No split DNS zones required — Pi-hole's local record overrides the public Cloudflare record for internal clients, because Pi-hole resolves before any public query leaves the network.
+
+---
+
+## Verification
+
+```bash
+# From inside your LAN, verify the local DNS record resolves
+dig service.yourdomain.com @192.168.1.x   # replace with Pi-hole IP
+# Should return NPM's internal IP
+
+# Verify HTTPS works
+curl -I https://service.yourdomain.com
+# Should return HTTP 200 with valid certificate details
+```
+
+In a browser, the padlock should show a valid certificate issued by Let's Encrypt (or ZeroSSL).
+
+---
+
+## Common Gotchas
+
+| Problem | Cause | Fix |
+|---------|-------|-----|
+| Certificate request fails | Cloudflare API token lacks DNS edit permission | Check token permissions in Cloudflare dashboard |
+| Browser shows "not secure" | Certificate issued for wrong hostname | Check NPM proxy host domain matches Pi-hole record |
+| `502 Bad Gateway` | Service not running or wrong IP/port | Verify backend is reachable from NPM host |
+| HTTP_REFERER errors in OPNsense | Hostname not in Alternate Hostnames | Add to System → Settings → Administration |
+| Internal clients still hitting public IP | Pi-hole local record missing | Add local DNS record in Pi-hole |
+
+---
+
+## Related Pages
+
+- [Cloudflare Tunnels](cloudflare-tunnels.md) — the public-facing counterpart
+- [Pi-hole + Unbound DNS](dns-stack.md) — Pi-hole setup and local DNS
+- [OPNsense on Zimaboard 2](opnsense-zimaboard.md) — Dnsmasq host overrides as an alternative to Pi-hole local DNS for LAN hostnames
+
+<a href="https://www.buymeacoffee.com/techdox"><img src="https://img.buymeacoffee.com/button-api/?text=Buy me a cup of tea&emoji=🍵&slug=techdox&button_colour=FFDD00&font_colour=000000&font_family=Cookie&outline_colour=000000&coffee_colour=ffffff" /></a>
+
+---
+
+If there is an issue with this guide or you wish to suggest changes, please raise an issue on [GitHub](https://github.com/Techdox/techdox-docs).

--- a/docs/homelab-rebuild/macos-hardening.md
+++ b/docs/homelab-rebuild/macos-hardening.md
@@ -1,0 +1,162 @@
+---
+title: macOS Security Hardening
+description: Practical macOS hardening using native protections and the Objective-See free toolkit. No third-party antivirus required.
+---
+<a href="https://my.racknerd.com/aff.php?aff=5792&ref=techdox.nz" target="_blank">
+    <img src="https://racknerd.com/banners/728x90.gif" alt="RackNerd Hosting Deals">
+</a>
+
+# macOS Security Hardening
+
+macOS has strong built-in security features that most users leave misconfigured, plus a set of free tools from [Objective-See](https://objective-see.org/) that add meaningful protection without the bloat of commercial antivirus. This guide covers both — what to enable natively and what to add on top.
+
+## Prerequisites
+
+- macOS Ventura or later (Sonoma/Sequoia recommended)
+- Admin access to your Mac
+- Apple Account with two-factor authentication enabled
+
+---
+
+## Native macOS Protections
+
+Work through each of these. Most are off or misconfigured on a fresh Mac.
+
+### FileVault (Full Disk Encryption)
+
+**System Settings → Privacy & Security → FileVault**
+
+Turn on FileVault. This encrypts your entire disk — if your Mac is stolen or powered off, the data is unreadable without your login password.
+
+!!! warning "Save your recovery key securely"
+    macOS offers to store your FileVault recovery key with Apple or give you a local key. Store the local key in your password manager (e.g., Proton Pass). If you forget your password and don't have the recovery key, the data is gone.
+
+### Application Firewall
+
+**System Settings → Network → Firewall → Turn On**
+
+Then click **Options** and enable **Block all incoming connections** except the services you explicitly need. The application firewall blocks inbound connections app-by-app — it's a different layer to LuLu (which handles outbound).
+
+!!! note
+    macOS's built-in firewall only handles inbound. For outbound control (which apps can phone home), use LuLu — see below.
+
+### Find My Mac + Remote Wipe
+
+**Apple Account → iCloud → Find My Mac** — enable this.
+
+If your Mac is lost or stolen:
+1. Sign into [icloud.com](https://icloud.com) from another device
+2. Go to **Find My → All Devices**
+3. Erase the device remotely before someone can brute-force the login
+
+### Screen Lock
+
+**System Settings → Lock Screen**
+
+- **Require password after screen saver begins**: Immediately
+- **Require password after sleep begins**: Immediately
+
+A screen that locks after 5 minutes is an open door if you step away.
+
+### iCloud Advanced Data Protection (ADP)
+
+**Apple Account → iCloud → Advanced Data Protection**
+
+When enabled, your iCloud data (backups, photos, notes, etc.) is end-to-end encrypted — even Apple can't access it. This is off by default.
+
+!!! warning "Set up a recovery contact or key before enabling"
+    With ADP on, Apple cannot help you recover your account. Set up an account recovery contact (trusted person) or recovery key before enabling, otherwise you risk permanent lockout.
+
+---
+
+## Objective-See Tools
+
+These are free, open-source tools from Patrick Wardle's [Objective-See](https://objective-see.org/). Unlike commercial antivirus, they add specific controls rather than scanning for signatures of already-known malware.
+
+### LuLu — Outbound Application Firewall
+
+[Download LuLu](https://objective-see.org/products/lulu.html)
+
+LuLu prompts you every time a new application attempts an outbound network connection. You can allow or deny it permanently. This lets you:
+
+- See which apps are phoning home
+- Block apps from making unexpected connections
+- Catch new apps that attempt network access before you've reviewed them
+
+On first install, you'll get a flurry of prompts as LuLu learns your existing apps. After the initial approval phase, it's quiet.
+
+### BlockBlock — Persistence Monitor
+
+[Download BlockBlock](https://objective-see.org/products/blockblock.html)
+
+Malware often survives reboots by installing persistence mechanisms (launch agents, login items, browser extensions). BlockBlock alerts you whenever anything tries to add a persistent item to your Mac.
+
+### KnockKnock — Startup Item Auditor
+
+[Download KnockKnock](https://objective-see.org/products/knockknock.html)
+
+Run this quarterly as an audit tool (it's not a background daemon). It scans all persistence locations and shows everything that runs at startup, with VirusTotal ratings for unknown items.
+
+### OverSight — Mic and Camera Monitor
+
+[Download OverSight](https://objective-see.org/products/oversight.html)
+
+OverSight sits in the menu bar and alerts you when any process activates the microphone or camera. Useful for catching apps that listen when they shouldn't.
+
+---
+
+## App Privacy Report
+
+**System Settings → Privacy & Security → App Privacy Report → Turn On**
+
+After a week of use, this shows you which apps accessed your location, contacts, camera, microphone, and — most usefully — which domains they connected to. It's the built-in equivalent of LuLu's connection log.
+
+---
+
+## What to Avoid
+
+| Product / Action | Why |
+|-----------------|-----|
+| Traditional antivirus (Norton, McAfee, Kaspersky) | macOS has XProtect built in. Third-party AV adds attack surface and system extension access without meaningful protection gain |
+| CleanMyMac and similar "optimizers" | Deep system access, questionable benefit, often flagged by security researchers |
+| Disabling SIP (System Integrity Protection) | SIP prevents malware from modifying core OS files. Never disable this in production |
+| Running daily tasks as an admin user | Create a standard user account for daily use, use admin only for installs and settings changes |
+
+---
+
+## Account Setup Best Practice
+
+macOS lets you have multiple user accounts. The recommended setup:
+
+1. **Admin account** — used only for system changes, software installs, System Settings. Not your day-to-day login.
+2. **Standard account** — your daily driver. Apps run with limited permissions.
+
+This limits the blast radius of any compromised app or browser exploit — it runs as a standard user, not an admin.
+
+---
+
+## Verification Checklist
+
+- [ ] FileVault: **On**, recovery key saved in password manager
+- [ ] Application Firewall: **On**
+- [ ] Screen lock: **Immediately**
+- [ ] Find My Mac: **On**
+- [ ] iCloud Advanced Data Protection: **On**
+- [ ] LuLu: installed and active (menu bar icon visible)
+- [ ] BlockBlock: installed and active
+- [ ] OverSight: installed and active
+- [ ] App Privacy Report: **On**
+- [ ] Daily user account is a **Standard** account, not Admin
+
+---
+
+## Related Pages
+
+- [YubiKey SSH](yubikey-ssh.md) — hardware-bound SSH authentication for your servers
+- [Proton Mail Migration](proton-mail-custom-domain.md) — privacy-focused email to pair with device hardening
+
+<a href="https://www.buymeacoffee.com/techdox"><img src="https://img.buymeacoffee.com/button-api/?text=Buy me a cup of tea&emoji=🍵&slug=techdox&button_colour=FFDD00&font_colour=000000&font_family=Cookie&outline_colour=000000&coffee_colour=ffffff" /></a>
+
+---
+
+If there is an issue with this guide or you wish to suggest changes, please raise an issue on [GitHub](https://github.com/Techdox/techdox-docs).

--- a/docs/homelab-rebuild/opnsense-zimaboard.md
+++ b/docs/homelab-rebuild/opnsense-zimaboard.md
@@ -1,0 +1,227 @@
+---
+title: Migrating to OPNsense on Zimaboard 2
+description: How to replace a consumer mesh router with OPNsense running on a Zimaboard 2, covering hardware, install, DHCP with Dnsmasq, host overrides, and the physical cutover.
+---
+<a href="https://my.racknerd.com/aff.php?aff=5792&ref=techdox.nz" target="_blank">
+    <img src="https://racknerd.com/banners/728x90.gif" alt="RackNerd Hosting Deals">
+</a>
+
+# Migrating to OPNsense on Zimaboard 2
+
+I replaced a TP-Link Deco mesh system with OPNsense running on a Zimaboard 2. The Deco now runs purely as Wi-Fi access points — routing, DNS, DHCP, firewall, and VPN all moved to OPNsense. This guide walks through the full process, including the gotchas that most OPNsense guides skip.
+
+## Prerequisites
+
+- Zimaboard 2 (or similar x86_64 SBC with dual NICs)
+- USB stick (4 GB or larger)
+- Monitor and keyboard for the initial install
+- A spare computer for flashing the USB
+- [Balena Etcher](https://etcher.balena.io/) installed
+- Your current network documented (see Pre-cutover prep below)
+
+---
+
+## Hardware: Zimaboard 2
+
+The [Zimaboard 2](https://www.zimaboard.com/) is a single-board server with dual 2.5GbE NICs, an x86_64 Intel processor, and onboard eMMC storage. It's a solid choice for a home router:
+
+- **Dual 2.5GbE** — one WAN, one LAN (connect to your switch or AP)
+- **x86_64** — full OPNsense compatibility, including Suricata IDS
+- **Passive cooling** — no fan, no noise
+- **Low power** — suitable for always-on use
+
+---
+
+## Pre-Cutover Preparation
+
+Before pulling the plug on your existing router, document your current setup. You'll need this to recreate it in OPNsense.
+
+- [ ] WAN connection type (most home connections are DHCP from the ISP — no PPPoE needed)
+- [ ] Your current LAN subnet (e.g., `192.168.1.0/24`)
+- [ ] DHCP range your router is using
+- [ ] Any static/reserved IPs (hostname, IP, MAC address for each)
+- [ ] Any port forwards you need to recreate
+- [ ] Your current DNS config (what upstream DNS servers are set)
+
+!!! tip
+    If you're migrating to Pi-hole + Unbound (see [DNS Stack](dns-stack.md)), note your Pi-hole's IP now — you'll point OPNsense's DHCP at it during setup.
+
+---
+
+## Installation
+
+### 1. Download OPNsense
+
+Go to [opnsense.org/download](https://opnsense.org/download/) and download:
+
+- **Architecture**: amd64
+- **Image type**: vga (not serial)
+- **Format**: `.img.bz2`
+
+### 2. Decompress and Flash
+
+On macOS, double-clicking the `.img.bz2` decompresses it automatically. Then flash to your USB stick with Balena Etcher.
+
+!!! warning
+    Etcher will erase the USB stick. Make sure you select the correct drive.
+
+### 3. Boot the Zimaboard from USB
+
+Connect monitor, keyboard, and USB stick to the Zimaboard. Power it on and boot from USB (you may need to press `F11` or `Del` during POST to select the boot device).
+
+### 4. Run the Installer
+
+At the login prompt:
+
+```
+Username: installer
+Password: opnsense
+```
+
+When the installer starts:
+
+1. Accept the default keymap (or select yours)
+2. Choose **Install (ZFS)** — more resilient than UFS for flash storage
+3. Stripe layout (no RAID — single device)
+4. Select the **internal eMMC** as the install target — **not your USB stick**
+5. Set a root password when prompted
+
+!!! warning "Keyboard layout during install"
+    If you change the keymap during install, make sure you type your root password using that layout. Mismatches here cause login failures later and are hard to debug remotely.
+
+### 5. Remove USB and Reboot
+
+Once the install completes, remove the USB stick and let the Zimaboard reboot into OPNsense.
+
+---
+
+## Initial Configuration
+
+OPNsense defaults to `192.168.1.1` on the LAN interface. Connect a laptop or Raspberry Pi directly to the LAN port via Ethernet and browse to `https://192.168.1.1`.
+
+Default credentials: `root` / the password you set during install.
+
+### Run the Setup Wizard
+
+The wizard runs on first login. Work through each step:
+
+**General**
+
+- Hostname: whatever you want (e.g., `router`)
+- Domain: `local` or `localdomain`
+- Primary DNS: your Pi-hole IP (e.g., `192.168.1.x`) — you'll update this after cutover
+- Uncheck **Override DNS**
+
+**WAN Interface**
+
+- Type: **DHCP** (for most home broadband connections)
+- MTU: 1500
+- Enable **Block private networks** and **Block bogon networks**
+
+**LAN Interface**
+
+- Change the IP to match your existing subnet (e.g., `192.168.1.1/24`)
+- Reconnect at the new IP after the wizard saves
+
+!!! tip
+    If you're keeping your existing subnet (e.g., `192.168.1.0/24`), your devices won't need to renew leases after cutover.
+
+---
+
+## DHCP Configuration (Dnsmasq)
+
+!!! note "OPNsense v26 uses Dnsmasq by default"
+    OPNsense 26.x switched to **Dnsmasq** as the default DHCP server, replacing Kea. Most older guides and forum posts reference Kea or ISC DHCP — ignore those settings. Look for **Services → Dnsmasq DNS & DHCP**.
+
+Navigate to **Services → Dnsmasq DNS & DHCP → General** and configure:
+
+- **DHCP Range**: Set a start and end IP that leaves room for your static reservations outside the pool. Example: `192.168.1.100` to `192.168.1.250`
+- **DHCP Option 6** (DNS server): Point this at your Pi-hole IP. This tells every DHCP client to use Pi-hole for DNS.
+
+```
+Option: 6 (dns-server)
+Value: 192.168.1.x    ← your Pi-hole's IP
+```
+
+- **Dnsmasq DNS listen port**: Leave at `53053` — this avoids conflicting with Pi-hole on port 53 if they're on the same host. Since Pi-hole is on a separate machine, this doesn't matter, but leaving it non-standard avoids confusion.
+- **Disable Unbound DNS**: Go to **Services → Unbound DNS** and disable it. Pi-hole owns DNS in this setup; you don't want Unbound competing.
+
+---
+
+## Host Overrides — DHCP Reservations + Local DNS in One
+
+This is one of the most useful features of Dnsmasq that most guides underexplain. Under **Services → Dnsmasq DNS & DHCP → Hosts**, you can add entries that serve two purposes simultaneously:
+
+1. **DHCP reservation** — the device always gets the same IP via MAC address
+2. **Local DNS record** — the hostname resolves on your LAN without needing Pi-hole local DNS records
+
+For each server or device that needs a stable IP:
+
+| Field | Value |
+|-------|-------|
+| Host | `pihole-host` |
+| Domain | `local` |
+| IP address | `192.168.1.x` |
+| MAC address | `aa:bb:cc:dd:ee:ff` |
+| Tick **Local** | ✅ |
+
+With **Local** ticked, `pihole-host.local` resolves to that IP from any device on the network — no separate Pi-hole local DNS record needed for LAN hosts.
+
+!!! tip
+    Set up all your reservations here before cutover so devices get the right IPs from the first DHCP lease.
+
+---
+
+## The Physical Cutover
+
+Once OPNsense is configured and you've verified it boots and accepts your login:
+
+1. **Switch your Deco (or other mesh AP) to Access Point mode** — in the Deco app: More → Advanced → Operating Mode → Access Point. This disables its DHCP server and routing.
+2. Unplug the fibre/coax cable from your old router's WAN port
+3. Plug it into the Zimaboard's WAN port
+4. Plug the Zimaboard's LAN port into your switch or directly into the main Deco/AP
+5. Wait ~60 seconds for the WAN DHCP lease to come up
+6. Test from a connected device — you should have internet within a minute
+
+---
+
+## Verification
+
+```bash
+# Check you're getting DNS from Pi-hole
+cat /etc/resolv.conf           # should show your Pi-hole IP
+
+# Test internet
+ping -c 3 1.1.1.1
+
+# Check DNS works
+dig google.com @192.168.1.x    # replace with Pi-hole IP
+```
+
+From the OPNsense dashboard: **Lobby → Dashboard** should show WAN with an IP from your ISP.
+
+---
+
+## Common Gotchas
+
+| Problem | Cause | Fix |
+|---------|-------|-----|
+| Changes not taking effect | Forgot to click **Apply** | Every change in OPNsense requires the Apply button |
+| No internet after cutover | ISP MAC binding (rare) | Clone your old router's MAC under Interfaces → WAN |
+| Can't log in after install | Keyboard layout mismatch during password entry | Console reset via physical access |
+| DHCP not working | Dnsmasq not enabled | Services → Dnsmasq DNS & DHCP → General → Enable |
+| Devices not resolving local hostnames | Local tick not checked on host override | Edit each host override, tick Local, apply |
+
+---
+
+## Related Pages
+
+- [Pi-hole + Unbound DNS Stack](dns-stack.md) — configure DNS after OPNsense is running
+- [WireGuard VPN](wireguard-vpn.md) — add VPN to your OPNsense router
+- [Internal Hostnames](internal-hostnames.md) — serving internal services with proper TLS
+
+<a href="https://www.buymeacoffee.com/techdox"><img src="https://img.buymeacoffee.com/button-api/?text=Buy me a cup of tea&emoji=🍵&slug=techdox&button_colour=FFDD00&font_colour=000000&font_family=Cookie&outline_colour=000000&coffee_colour=ffffff" /></a>
+
+---
+
+If there is an issue with this guide or you wish to suggest changes, please raise an issue on [GitHub](https://github.com/Techdox/techdox-docs).

--- a/docs/homelab-rebuild/proton-mail-custom-domain.md
+++ b/docs/homelab-rebuild/proton-mail-custom-domain.md
@@ -1,0 +1,203 @@
+---
+title: Migrating Email to Proton Mail with Custom Domain
+description: Step-by-step guide to migrating your email from any provider to Proton Mail with a custom domain, including MX, SPF, DKIM, DMARC setup and importing historical mail.
+---
+<a href="https://my.racknerd.com/aff.php?aff=5792&ref=techdox.nz" target="_blank">
+    <img src="https://racknerd.com/banners/728x90.gif" alt="RackNerd Hosting Deals">
+</a>
+
+# Migrating Email to Proton Mail with Custom Domain
+
+Moving email to Proton Mail with your own domain means your email address isn't tied to any provider — you can move again later without changing your address. This guide covers the full migration: domain verification, MX cutover, SPF/DKIM/DMARC, and importing historical mail.
+
+## Prerequisites
+
+- [Proton Mail Plus](https://proton.me/mail/pricing) or higher (free plan doesn't support custom domains)
+- A domain with DNS managed through Cloudflare (examples use Cloudflare, but the records are the same on any provider)
+- Access to your current email provider to export/import mail
+- 15–30 minutes of DNS propagation time
+
+---
+
+## Pre-Migration Assessment
+
+Before touching DNS, inventory what's already there. Log into your Cloudflare DNS panel and note every record related to email:
+
+- **MX records** — pointing to your current mail provider
+- **TXT records** — SPF (`v=spf1 ...`) and possibly DMARC (`v=DMARC1 ...`)
+- **CNAME records** — DKIM keys for your current provider
+- **Domain verification TXTs** — may be required by your current provider
+
+!!! tip
+    If you use transactional email services (e.g., Mailgun, SendGrid, Zendesk) on **subdomains** (e.g., `mail.yourdomain.com`), these are separate from your root domain's email and won't be affected by this migration. Only touch records at the root (`@`).
+
+---
+
+## Step 1: Verify Domain Ownership with Proton
+
+1. Log into Proton Mail → **Settings → Domain names → Add custom domain**
+2. Enter your domain
+3. Proton will provide a verification TXT record:
+
+```
+Type: TXT
+Name: @
+Value: protonmail-verification=<your-unique-string>
+```
+
+Add this to your Cloudflare DNS (do **not** wrap the value in quotes — Cloudflare adds them automatically).
+
+4. Click **Verify** in Proton. Propagation usually takes under 5 minutes with Cloudflare.
+
+---
+
+## Step 2: Add Email Addresses
+
+Before cutting over MX, add the addresses you want in Proton:
+
+1. In Proton domain settings → **Addresses tab**
+2. Add your primary address (e.g., `you@yourdomain.com`)
+3. Add any aliases you need
+
+---
+
+## Step 3: MX Cutover
+
+This is the step that switches inbound mail delivery from your old provider to Proton.
+
+**Remove** your current MX records (e.g., the ones pointing to iCloud, Google, or wherever).
+
+**Add** Proton's MX records:
+
+```
+Type: MX  Name: @  Priority: 10  Value: mail.protonmail.ch
+Type: MX  Name: @  Priority: 20  Value: mailsec.protonmail.ch
+```
+
+!!! warning "Brief delivery gap"
+    There may be a short window (minutes, not hours with Cloudflare) where some mail goes to the old provider and some to Proton. If zero-gap migration matters, do the cutover late at night and import any straggler mail from the old provider afterward.
+
+---
+
+## Step 4: SPF
+
+SPF tells receiving servers which hosts are authorised to send mail for your domain.
+
+**Remove** your existing SPF TXT record (there must only be one SPF record per domain).
+
+**Add** Proton's:
+
+```
+Type: TXT  Name: @  Value: v=spf1 include:_spf.protonmail.ch ~all
+```
+
+!!! warning "Only one SPF record allowed"
+    Multiple SPF records cause authentication failures. If you have an existing SPF record, replace it entirely — don't add a second one.
+
+---
+
+## Step 5: DKIM
+
+DKIM lets receiving servers verify that outbound mail actually came from Proton and wasn't tampered with. Proton uses three CNAME records for key rotation:
+
+```
+Type: CNAME  Name: protonmail._domainkey
+Value: protonmail.domainkey.<your-id>.domains.proton.ch
+
+Type: CNAME  Name: protonmail2._domainkey
+Value: protonmail2.domainkey.<your-id>.domains.proton.ch
+
+Type: CNAME  Name: protonmail3._domainkey
+Value: protonmail3.domainkey.<your-id>.domains.proton.ch
+```
+
+The exact values are shown in your Proton domain settings — copy them directly.
+
+!!! warning "Set DKIM CNAMEs to DNS-only in Cloudflare"
+    Make sure the orange Cloudflare proxy cloud is **off** (grey/DNS-only) for these CNAME records. Proxying DKIM records breaks validation.
+
+---
+
+## Step 6: DMARC
+
+DMARC tells receiving servers what to do with mail that fails SPF or DKIM checks, and optionally sends you reports.
+
+```
+Type: TXT  Name: _dmarc
+Value: v=DMARC1; p=quarantine; rua=mailto:dmarc@yourdomain.com
+```
+
+- `p=quarantine` — suspicious mail goes to spam rather than being rejected outright. Switch to `p=reject` once you're confident everything is working.
+- `rua=` — address for aggregate reports (optional but useful for spotting misconfiguration)
+
+---
+
+## Verification
+
+Once all records are in place, verify from the command line:
+
+```bash
+# MX records
+dig MX yourdomain.com +short
+# Should show: mail.protonmail.ch and mailsec.protonmail.ch
+
+# SPF
+dig TXT yourdomain.com +short
+# Should include: v=spf1 include:_spf.protonmail.ch ~all
+
+# DKIM
+dig CNAME protonmail._domainkey.yourdomain.com +short
+# Should return a protonmail.domainkey.*.domains.proton.ch value
+
+# DMARC
+dig TXT _dmarc.yourdomain.com +short
+# Should return your DMARC policy
+```
+
+You can also use [MXToolbox](https://mxtoolbox.com/) or [mail-tester.com](https://www.mail-tester.com/) for a visual check.
+
+---
+
+## Set Up a Catch-All
+
+A catch-all forwards any `*@yourdomain.com` address to your inbox — useful so you never miss mail sent to old addresses or aliases you've used over the years.
+
+1. Proton domain settings → **Catch-all**
+2. Point it at your primary address
+
+---
+
+## Import Historical Mail
+
+If you're migrating from another provider, you can import your existing mail into Proton:
+
+1. **Settings → Import via Easy Switch**
+2. Select your current provider
+3. For Apple iCloud: generate an app-specific password at [appleid.apple.com](https://appleid.apple.com) (iCloud doesn't allow regular passwords for third-party access)
+4. Enter your email + app-specific password
+5. Select folders/labels to import
+6. The import runs in the background — large mailboxes can take hours
+
+---
+
+## Common Pitfalls
+
+| Problem | Cause | Fix |
+|---------|-------|-----|
+| Verification TXT fails | Added quotes around value | Remove manual quotes — Cloudflare adds them |
+| SPF fails | Two SPF records exist | Delete old SPF, keep only the Proton one |
+| DKIM fails | CNAMEs proxied through Cloudflare | Set to DNS-only (grey cloud) |
+| Mail going to old provider | MX records not updated | Verify MX with `dig MX yourdomain.com` |
+| `p=reject` DMARC drops mail | DKIM/SPF not fully propagated | Use `p=quarantine` first, move to `p=reject` after a week |
+
+---
+
+## Related Pages
+
+- [macOS Hardening](macos-hardening.md) — full device security posture to pair with privacy-focused email
+
+<a href="https://www.buymeacoffee.com/techdox"><img src="https://img.buymeacoffee.com/button-api/?text=Buy me a cup of tea&emoji=🍵&slug=techdox&button_colour=FFDD00&font_colour=000000&font_family=Cookie&outline_colour=000000&coffee_colour=ffffff" /></a>
+
+---
+
+If there is an issue with this guide or you wish to suggest changes, please raise an issue on [GitHub](https://github.com/Techdox/techdox-docs).

--- a/docs/homelab-rebuild/wireguard-vpn.md
+++ b/docs/homelab-rebuild/wireguard-vpn.md
@@ -1,0 +1,216 @@
+---
+title: WireGuard VPN on OPNsense
+description: Set up WireGuard directly on your OPNsense router for kernel-level VPN performance, native firewall integration, and secure remote access with split or full tunnel support.
+---
+<a href="https://my.racknerd.com/aff.php?aff=5792&ref=techdox.nz" target="_blank">
+    <img src="https://racknerd.com/banners/728x90.gif" alt="RackNerd Hosting Deals">
+</a>
+
+# WireGuard VPN on OPNsense
+
+Running WireGuard directly on OPNsense means your VPN lives at the kernel level inside the router — not in a container or on a separate host. This gives you better performance, native firewall integration, and a cleaner architecture. Remote clients connect to your router, and routing decisions happen at the same place as all other firewall rules.
+
+## Prerequisites
+
+- OPNsense installed and running (see [OPNsense on Zimaboard 2](opnsense-zimaboard.md))
+- WAN port with a reachable IP (static or DDNS)
+- UDP port 51820 accessible from the internet (you'll add the firewall rule below)
+- WireGuard client app on your devices ([iOS](https://apps.apple.com/app/wireguard/id1441195209), [Android](https://play.google.com/store/apps/details?id=com.wireguard.android), [macOS](https://apps.apple.com/app/wireguard/id1451685025))
+
+---
+
+## Why WireGuard on the Router?
+
+| Approach | Pros | Cons |
+|----------|------|------|
+| WireGuard on OPNsense | Kernel performance, native firewall rules, single config point | Slightly more complex initial setup |
+| WireGuard in a container | Easy to set up initially | Requires port forwarding, extra NAT hop, no native firewall integration |
+| WireGuard on a separate VM | Isolated | More hardware, extra management |
+
+---
+
+## Step 1: Create the WireGuard Server Instance
+
+Navigate to **VPN → WireGuard → Instances → Add**:
+
+| Field | Value |
+|-------|-------|
+| Name | `wg0` (or any name) |
+| Listen Port | `51820` |
+| Tunnel Address | `10.10.10.1/24` |
+| Generate keypair | Click the generate button |
+
+!!! warning "Tunnel subnet must not overlap with your LAN"
+    If your LAN is `192.168.1.0/24`, your WireGuard tunnel must use a different subnet entirely (e.g., `10.10.10.0/24`). Overlap here causes routing failures that are annoying to diagnose.
+
+Save the instance. Note the **public key** — you'll need it when configuring client configs.
+
+---
+
+## Step 2: Add Peers via the Peer Generator
+
+The Peer Generator (**VPN → WireGuard → Peer Generator**) lets you create a peer config and QR code in one step.
+
+For each device (phone, laptop, etc.):
+
+| Field | Value |
+|-------|-------|
+| Name | Descriptive (e.g., `iphone`, `macbook`) |
+| Tunnel Address | Unique IP in the tunnel subnet (e.g., `10.10.10.2/32`) |
+| DNS | Your Pi-hole IP (e.g., `192.168.1.x`) |
+| Pre-shared key | Generate one |
+| Endpoint | `<your-wan-ip>:51820` or your DDNS hostname |
+| Allowed IPs | See split vs full tunnel below |
+| Keepalive | `25` |
+
+!!! warning "Scroll down and Save before scanning the QR"
+    The Peer Generator shows a QR code, but the peer is **not saved to the instance** until you scroll to the bottom and click **Save**. After saving, go to **VPN → WireGuard → Peers** and confirm your peer appears, then edit your WireGuard Instance and make sure the peer is selected in the **Peers** dropdown.
+
+---
+
+## Split Tunnel vs Full Tunnel
+
+The **Allowed IPs** field on each peer controls what traffic goes through the VPN.
+
+### Full Tunnel (phone — all traffic via VPN)
+
+```
+Allowed IPs: 0.0.0.0/0, ::/0
+```
+
+All traffic — including regular browsing — routes through your home connection. Useful on cellular where you want Pi-hole's ad blocking everywhere.
+
+### Split Tunnel (laptop — homelab only)
+
+```
+Allowed IPs: 192.168.1.0/24, 10.10.10.0/24
+```
+
+Only traffic destined for your LAN or other VPN peers routes through the tunnel. General browsing uses the device's local internet. Faster for daily use, lower load on your home connection.
+
+!!! tip
+    Use full tunnel for phones (you get Pi-hole ad blocking on cellular) and split tunnel for laptops (general browsing isn't bottlenecked by your home upload speed).
+
+---
+
+## Step 3: Firewall Rules
+
+Two rules are required.
+
+### Rule 1 — Allow WireGuard traffic in on WAN
+
+**Firewall → Rules → WAN → Add**
+
+| Field | Value |
+|-------|-------|
+| Action | Pass |
+| Direction | In |
+| Protocol | UDP |
+| Source | any |
+| Destination | WAN address |
+| Destination port | 51820 |
+
+### Rule 2 — Allow traffic through the tunnel
+
+**Firewall → Rules → WireGuard (tab) → Add**
+
+| Field | Value |
+|-------|-------|
+| Action | Pass |
+| Direction | In |
+| Protocol | any |
+| Source | any |
+| Destination | any |
+
+---
+
+## Step 4: Outbound NAT (the part most guides miss)
+
+This is where most WireGuard-on-OPNsense setups break. Without the correct NAT rules, VPN clients can reach LAN hosts but DNS replies from Pi-hole get silently dropped, and internet traffic doesn't route correctly.
+
+First, set NAT mode to **Hybrid**: **Firewall → NAT → Outbound** → select **Hybrid Outbound NAT**.
+
+Add two rules:
+
+### NAT Rule 1 — Tunnel to Internet
+
+| Field | Value |
+|-------|-------|
+| Interface | WAN |
+| Source | WireGuard (Group) net |
+| Translation | Interface address |
+
+This masquerades VPN client traffic behind your WAN IP so it can reach the internet.
+
+### NAT Rule 2 — Tunnel to LAN
+
+| Field | Value |
+|-------|-------|
+| Interface | LAN |
+| Source | WireGuard (Group) net |
+| Translation | Interface address |
+
+!!! warning "This rule is critical and commonly missed"
+    Without this rule, VPN clients can ping LAN hosts and even open connections, but DNS responses from Pi-hole get dropped. The symptom is that DNS lookups time out or return nothing even though ping to the Pi-hole IP works. Adding this LAN NAT rule fixes it.
+
+---
+
+## Step 5: Client Setup
+
+### iPhone / Android
+
+1. Open the WireGuard app
+2. Tap **+** → **Create from QR code**
+3. Scan the QR from the Peer Generator
+4. Enable the tunnel
+
+### macOS
+
+1. Open the WireGuard app (Mac App Store)
+2. Click **+** → **Add Empty Tunnel**
+3. Paste your peer config directly (copy from OPNsense peer view)
+
+Alternatively, export the config file and drag it into the WireGuard app.
+
+---
+
+## Verification
+
+```bash
+# From a device on cellular with VPN enabled
+curl -I https://google.com
+# Should return HTTP headers — internet routing works
+
+ping -c 3 192.168.1.x   # your Pi-hole IP
+# Should reply — LAN is reachable through tunnel
+
+nslookup doubleclick.net
+# Should return 0.0.0.0 — Pi-hole filtering works through VPN
+```
+
+In OPNsense: **VPN → WireGuard → Status** should show your peer with a recent handshake time and bytes transferred.
+
+---
+
+## Common Gotchas
+
+| Problem | Cause | Fix |
+|---------|-------|-----|
+| Peer not saving | Didn't click Save at bottom of Peer Generator | Scroll to bottom and Save; verify in Peers tab |
+| Peer not appearing in instance | Peer saved but not linked to instance | Edit Instance → select peer in Peers dropdown → Apply |
+| DNS not working through VPN | Missing LAN NAT rule | Add NAT Rule 2 (Tunnel to LAN) |
+| Internet not working through full tunnel | Missing WAN NAT rule | Add NAT Rule 1 (Tunnel to WAN) |
+| Can't connect from outside | WAN firewall rule missing | Add UDP 51820 pass rule on WAN |
+
+---
+
+## Related Pages
+
+- [OPNsense on Zimaboard 2](opnsense-zimaboard.md) — router setup prerequisite
+- [Pi-hole + Unbound DNS](dns-stack.md) — Pi-hole DNS filtering extends through the VPN with the LAN NAT rule
+
+<a href="https://www.buymeacoffee.com/techdox"><img src="https://img.buymeacoffee.com/button-api/?text=Buy me a cup of tea&emoji=🍵&slug=techdox&button_colour=FFDD00&font_colour=000000&font_family=Cookie&outline_colour=000000&coffee_colour=ffffff" /></a>
+
+---
+
+If there is an issue with this guide or you wish to suggest changes, please raise an issue on [GitHub](https://github.com/Techdox/techdox-docs).

--- a/docs/homelab-rebuild/yubikey-ssh.md
+++ b/docs/homelab-rebuild/yubikey-ssh.md
@@ -1,0 +1,238 @@
+---
+title: YubiKey FIDO2 SSH Authentication
+description: Set up hardware-bound SSH authentication using a YubiKey and FIDO2 ed25519-sk keys. Works on macOS with Homebrew OpenSSH, requires physical key presence for every login.
+---
+<a href="https://my.racknerd.com/aff.php?aff=5792&ref=techdox.nz" target="_blank">
+    <img src="https://racknerd.com/banners/728x90.gif" alt="RackNerd Hosting Deals">
+</a>
+
+# YubiKey FIDO2 SSH Authentication
+
+Password SSH is a liability. Key-based SSH is better, but a private key file on disk can still be copied. FIDO2 SSH binds the key to the physical YubiKey — even if someone copies your entire filesystem, they can't SSH without the hardware token. This guide sets up `ed25519-sk` keys with PIN + touch required for every authentication.
+
+## Prerequisites
+
+- YubiKey 5 series (any form factor) — [YubiKey 5 NFC](https://www.yubico.com/au/product/yubikey-5-nfc/) recommended for iPhone NFC use
+- macOS with [Homebrew](https://brew.sh/) installed
+- Servers running OpenSSH 8.2+ (Ubuntu 20.04+, Debian 11+)
+- A second YubiKey for backup (strongly recommended — see [Backup](#backup-yubikey))
+
+---
+
+## Why FIDO2 (`ed25519-sk`) Over PIV/GPG?
+
+| Approach | Setup complexity | Key storage | Touch required |
+|----------|-----------------|-------------|----------------|
+| Regular `ed25519` | Simple | File on disk | ❌ |
+| PIV (SmartCard) | Complex | On YubiKey | Optional |
+| GPG subkey | Very complex | On YubiKey | Optional |
+| FIDO2 `ed25519-sk` | Simple | On YubiKey | ✅ mandatory |
+
+FIDO2 is the modern approach — simple to set up, well-supported in OpenSSH 8.2+, and the key physically cannot be used without the YubiKey present.
+
+---
+
+## macOS: Install Homebrew OpenSSH
+
+macOS ships with Apple's fork of OpenSSH, which doesn't include FIDO middleware support. You need Homebrew's OpenSSH.
+
+```bash
+brew install openssh libfido2
+```
+
+Add Homebrew's SSH to your PATH so it takes precedence over the system version. Add this to `~/.zshrc`:
+
+```bash
+export PATH="/opt/homebrew/opt/openssh/bin:$PATH"
+```
+
+Apply it:
+
+```bash
+source ~/.zshrc
+```
+
+Verify you're using the Homebrew version:
+
+```bash
+which ssh
+# Should output: /opt/homebrew/opt/openssh/bin/ssh
+
+ssh -V
+# Should show OpenSSH_9.x or 10.x
+```
+
+!!! warning
+    If `which ssh` still shows `/usr/bin/ssh`, the PATH change hasn't applied. Make sure you added it to `~/.zshrc` (not `~/.bash_profile`) and that you're using zsh (default on modern macOS).
+
+---
+
+## Set a FIDO2 PIN (First Time)
+
+If your YubiKey doesn't have a FIDO2 PIN set, you must set one before generating resident keys. The PIN is required to generate keys and to use `verify-required` keys.
+
+```bash
+brew install ykman
+ykman fido access change-pin
+```
+
+You'll be prompted to enter a new PIN (minimum 4 characters, 8+ recommended). This PIN is separate from your YubiKey's management key — it's specifically for FIDO2 operations.
+
+!!! tip
+    If you forget the FIDO2 PIN, you'll need to reset the FIDO2 application on the YubiKey with `ykman fido reset`. This **deletes all resident keys** stored on the key, so keep a backup.
+
+---
+
+## Generate the Key
+
+```bash
+ssh-keygen -t ed25519-sk \
+  -O resident \
+  -O verify-required \
+  -f ~/.ssh/id_ed25519_yubikey \
+  -C "yubikey-$(date +%Y%m%d)"
+```
+
+**Flag explanation:**
+
+| Flag | What it does |
+|------|--------------|
+| `-t ed25519-sk` | FIDO2 key type using Ed25519 curve |
+| `-O resident` | Stores the key handle on the YubiKey itself (re-derivable on new machines) |
+| `-O verify-required` | Requires PIN + touch for every use |
+| `-f ~/.ssh/id_ed25519_yubikey` | Output file for the local key handle |
+| `-C "yubikey-..."` | Comment to identify the key |
+
+You'll be prompted to:
+1. Touch your YubiKey (to confirm key generation)
+2. Enter your FIDO2 PIN
+
+Two files are created:
+- `~/.ssh/id_ed25519_yubikey` — local key handle (not the private key — the private key is on the YubiKey)
+- `~/.ssh/id_ed25519_yubikey.pub` — public key to deploy to servers
+
+---
+
+## Deploy the Public Key to Servers
+
+```bash
+ssh-copy-id -i ~/.ssh/id_ed25519_yubikey.pub user@server.local
+```
+
+Or manually: append the contents of `~/.ssh/id_ed25519_yubikey.pub` to `~/.ssh/authorized_keys` on the target server.
+
+### For OPNsense
+
+Navigate to **System → Access → Users**, edit your user, and paste the public key content into the **Authorized keys** field.
+
+---
+
+## SSH Config
+
+Create or update `~/.ssh/config` to make connections convenient:
+
+```
+Host *
+    IdentityFile ~/.ssh/id_ed25519_yubikey
+    IdentitiesOnly yes
+
+Host pihole-host
+    HostName 192.168.1.x
+    User your-username
+
+Host opnsense
+    HostName 192.168.1.1
+    User root
+```
+
+Replace `192.168.1.x` with your actual server IPs.
+
+Now `ssh pihole-host` will prompt for your YubiKey touch and PIN, then connect.
+
+---
+
+## Using the Resident Key on a New Machine
+
+The `-O resident` flag stores the key handle on the YubiKey itself. On a new Mac or after reinstalling:
+
+```bash
+# Plug in YubiKey and derive the local key handle
+ssh-keygen -K
+```
+
+This writes `id_ed25519_sk_rk` and `id_ed25519_sk_rk.pub` to `~/.ssh/`. You can rename these to match your config.
+
+---
+
+## Backup YubiKey
+
+!!! warning "Always register a second YubiKey before disabling password auth"
+    If you lose your only YubiKey and have disabled password SSH, you're locked out. Always:
+
+    1. Buy a second YubiKey
+    2. Generate a separate FIDO2 key on it: `ssh-keygen -t ed25519-sk -O resident -O verify-required -f ~/.ssh/id_ed25519_yubikey_backup -C "yubikey-backup-$(date +%Y%m%d)"`
+    3. Deploy the backup public key to every server
+    4. Store the backup YubiKey in a physically safe location
+    5. Only disable password auth after both keys are deployed and tested
+
+---
+
+## Disable Password SSH (After Backup is Set Up)
+
+Once both YubiKeys are deployed and tested, disable password authentication on each server:
+
+```bash
+sudo nano /etc/ssh/sshd_config
+```
+
+Set:
+
+```
+PasswordAuthentication no
+PubkeyAuthentication yes
+```
+
+Restart SSH:
+
+```bash
+sudo systemctl restart ssh
+```
+
+Test from a new terminal (don't close your current session) to confirm key auth works before fully committing.
+
+---
+
+## Verification
+
+```bash
+# Test connection — you should be prompted for touch + PIN
+ssh pihole-host
+
+# Confirm which key was used
+ssh -v pihole-host 2>&1 | grep "Offering"
+# Should show: Offering public key: ... sk-ssh-ed25519@openssh.com
+```
+
+---
+
+## Common Gotchas
+
+| Problem | Cause | Fix |
+|---------|-------|-----|
+| `sign_and_send_pubkey: signing failed` | YubiKey not plugged in | Insert YubiKey and retry |
+| Key generation fails with FIDO error | No FIDO2 PIN set | Run `ykman fido access change-pin` first |
+| `which ssh` returns `/usr/bin/ssh` | Homebrew PATH not set | Add to `~/.zshrc`, source it |
+| `verify-required` not prompting for PIN | Using system OpenSSH | Confirm Homebrew SSH is in PATH |
+| Locked out after disabling password auth | Lost YubiKey, no backup | Physical console access to re-enable password auth |
+
+---
+
+## Related Pages
+
+- [OPNsense on Zimaboard 2](opnsense-zimaboard.md) — add your YubiKey public key to OPNsense's SSH access
+
+<a href="https://www.buymeacoffee.com/techdox"><img src="https://img.buymeacoffee.com/button-api/?text=Buy me a cup of tea&emoji=🍵&slug=techdox&button_colour=FFDD00&font_colour=000000&font_family=Cookie&outline_colour=000000&coffee_colour=ffffff" /></a>
+
+---
+
+If there is an issue with this guide or you wish to suggest changes, please raise an issue on [GitHub](https://github.com/Techdox/techdox-docs).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -75,6 +75,17 @@ nav:
       - Overview: general-guides.md
       - Access Pihole via NPM: pihole-on-npm.md
       - Setting up Pihole Exporter: piexporter.md
+  - Homelab Rebuild:
+      - Overview: homelab-rebuild/index.md
+      - OPNsense on Zimaboard 2: homelab-rebuild/opnsense-zimaboard.md
+      - Pi-hole + Unbound DNS: homelab-rebuild/dns-stack.md
+      - WireGuard VPN: homelab-rebuild/wireguard-vpn.md
+      - YubiKey SSH: homelab-rebuild/yubikey-ssh.md
+      - Cloudflare Tunnels: homelab-rebuild/cloudflare-tunnels.md
+      - Internal Hostnames: homelab-rebuild/internal-hostnames.md
+      - Proton Mail Migration: homelab-rebuild/proton-mail-custom-domain.md
+      - macOS Hardening: homelab-rebuild/macos-hardening.md
+      - Architecture: homelab-rebuild/architecture.md
   - Resources:
       - Donate / Get Support: support.md
       - RackNerd Deals - Cheap VPS: racknerd.md


### PR DESCRIPTION
New section covering a complete homelab and privacy stack rebuild:
- index.md: Overview, goals, architecture diagram, component table
- opnsense-zimaboard.md: OPNsense install on Zimaboard 2, Dnsmasq DHCP, host overrides, cutover
- dns-stack.md: Pi-hole + Unbound recursive DNS, DNSSEC, verification
- wireguard-vpn.md: Router-level WireGuard, split/full tunnel, firewall + NAT rules (incl. LAN NAT gotcha)
- yubikey-ssh.md: FIDO2 ed25519-sk SSH, macOS Homebrew OpenSSH setup, backup key workflow
- cloudflare-tunnels.md: Zero-port-exposure public services, Docker Compose setup
- internal-hostnames.md: NPM + Pi-hole local DNS, DNS-01 certs, public/internal split
- proton-mail-custom-domain.md: MX/SPF/DKIM/DMARC migration, mail import
- macos-hardening.md: Native protections + Objective-See toolkit
- architecture.md: Full stack Mermaid diagrams across all layers

All examples use generic placeholders (yourdomain.com, 192.168.1.x) — no personal config exposed.